### PR TITLE
Allow best position to be drawn from topological neighborhood

### DIFF
--- a/shaders/update_global_best.frag
+++ b/shaders/update_global_best.frag
@@ -19,7 +19,7 @@ void main() {
         ivec2 global_best_idx = ivec2(re2.yz);
         global_best_idx += ivec2(round(cc)) * (dims/2);
         global_best_out = texelFetch(positions_texture, global_best_idx, 0);
-        best_error_value_out = vec4(re2.x, 0.0, 0.0, 0.0);
+        best_error_value_out = vec4(re2.xyz, 0.0);
     } else {
         global_best_out = texture(global_best_texture, cc);
         best_error_value_out = best_error;

--- a/shaders/update_topological_best_complete.frag
+++ b/shaders/update_topological_best_complete.frag
@@ -1,0 +1,14 @@
+#version 300 es
+
+precision highp float;
+precision highp int;
+
+uniform sampler2D best_error_value_texture;
+
+layout (location = 0) out uvec4 topological_best_idx;
+
+in vec2 cc;
+
+void main() {
+    topological_best_idx = uvec4(texelFetch(best_error_value_texture, ivec2(0, 0), 0).yz, 0u, 0u);
+}

--- a/shaders/update_topological_best_grid.frag
+++ b/shaders/update_topological_best_grid.frag
@@ -1,0 +1,36 @@
+#version 300 es
+
+precision highp float;
+precision highp int;
+
+uniform sampler2D local_bests_error_texture;
+
+layout (location = 0) out uvec4 topological_best_idx;
+
+in vec2 cc;
+
+void main() {
+    ivec2 texture_dims = textureSize(local_bests_error_texture, 0);
+    ivec2 particle_dims = texture_dims / 2;
+    ivec2 my_particle_idx = ivec2(floor(cc*vec2(particle_dims)));
+    int tex_size = particle_dims.x * particle_dims.y;
+
+    ivec2 locations[4];
+    locations[0] = my_particle_idx.x == 0 ? ivec2(tex_size-1, my_particle_idx.y) : ivec2(my_particle_idx.x-1, my_particle_idx.y);
+    locations[1] = my_particle_idx.x == tex_size-1 ? ivec2(0, my_particle_idx.y) : ivec2(my_particle_idx.x+1, my_particle_idx.y);
+    locations[2] = my_particle_idx.y == 0 ? ivec2(my_particle_idx.x, tex_size-1) : ivec2(my_particle_idx.x, my_particle_idx.y-1);
+    locations[3] = my_particle_idx.y == tex_size-1 ? ivec2(my_particle_idx.x, 0) : ivec2(my_particle_idx.x, my_particle_idx.y+1);
+
+    float cur_error = texelFetch(local_bests_error_texture, my_particle_idx, 0).x;
+    ivec2 best_idx = my_particle_idx;
+
+    for (int i = 0; i < 4; ++i) {
+        float new_error = texelFetch(local_bests_error_texture, locations[i], 0).x;
+        if (new_error < cur_error) {
+            cur_error = new_error;
+            best_idx = locations[i];
+        }
+    }
+
+    topological_best_idx = uvec4(best_idx, 0u, 0u);
+}

--- a/shaders/update_topological_best_ring.frag
+++ b/shaders/update_topological_best_ring.frag
@@ -1,0 +1,36 @@
+#version 300 es
+
+precision highp float;
+precision highp int;
+
+uniform sampler2D local_bests_error_texture;
+
+layout (location = 0) out uvec4 topological_best_idx;
+
+in vec2 cc;
+
+void main() {
+    ivec2 texture_dims = textureSize(local_bests_error_texture, 0);
+    ivec2 particle_dims = texture_dims / 2;
+    ivec2 my_particle_idx = ivec2(floor(cc*vec2(particle_dims)));
+    int my_particle_num = my_particle_idx.y * particle_dims.x + my_particle_idx.x;
+    int tex_size = particle_dims.x * particle_dims.y;
+
+    int pnums[2];
+    pnums[0] = my_particle_num == 0 ? tex_size - 1 : my_particle_num - 1;
+    pnums[1] = my_particle_num == tex_size-1 ? 0 : my_particle_num + 1;
+
+    float cur_error = texelFetch(local_bests_error_texture, my_particle_idx, 0).x;
+    ivec2 best_idx = my_particle_idx;
+
+    for (int i = 0; i < 2; ++i) {
+        ivec2 location = ivec2(pnums[i] % particle_dims.x, pnums[i] / particle_dims.x);
+        float new_error = texelFetch(local_bests_error_texture, location, 0).x;
+        if (new_error < cur_error) {
+            cur_error = new_error;
+            best_idx = location;
+        }
+    }
+
+    topological_best_idx = uvec4(best_idx, 0u, 0u);
+}


### PR DESCRIPTION
Rather than always using the global best as the known best position for every particle, some versions of PSO restrict each particle to only using the best value within its neighborhood. The neighborhood is usually defined as a static connectivity graph.

This feature still allows the use of the conventional global best method by simply using a complete connectivity graph.